### PR TITLE
Ensure that name is a required field on vault.identity.GroupAlias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Remove the autonaming of `vault.identify.GroupAlias`. The `name` must match that of the Github Team Name.
 
 ---
 

--- a/resources.go
+++ b/resources.go
@@ -262,7 +262,15 @@ func Provider() tfbridge.ProviderInfo {
 			"vault_identity_entity":       {Tok: makeResource(identityMod, "Entity")},
 			"vault_identity_entity_alias": {Tok: makeResource(identityMod, "EntityAlias")},
 			"vault_identity_group":        {Tok: makeResource(identityMod, "Group")},
-			"vault_identity_group_alias":  {Tok: makeResource(identityMod, "GroupAlias")},
+			"vault_identity_group_alias": {
+				Tok: makeResource(identityMod, "GroupAlias"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					//Fixes https://github.com/pulumi/pulumi-vault/issues/11
+					"name": {
+						Name: "name",
+					},
+				},
+			},
 			"vault_identity_group_policies": {
 				Tok: makeResource(identityMod, "GroupPolicies"),
 				Docs: &tfbridge.DocInfo{

--- a/sdk/dotnet/Identity/GroupAlias.cs
+++ b/sdk/dotnet/Identity/GroupAlias.cs
@@ -95,8 +95,8 @@ namespace Pulumi.Vault.Identity
         /// <summary>
         /// Name of the group alias to create.
         /// </summary>
-        [Input("name")]
-        public Input<string>? Name { get; set; }
+        [Input("name", required: true)]
+        public Input<string> Name { get; set; } = null!;
 
         public GroupAliasArgs()
         {

--- a/sdk/go/vault/identity/groupAlias.go
+++ b/sdk/go/vault/identity/groupAlias.go
@@ -26,6 +26,9 @@ func NewGroupAlias(ctx *pulumi.Context,
 	if args == nil || args.MountAccessor == nil {
 		return nil, errors.New("missing required argument 'MountAccessor'")
 	}
+	if args == nil || args.Name == nil {
+		return nil, errors.New("missing required argument 'Name'")
+	}
 	inputs := make(map[string]interface{})
 	if args == nil {
 		inputs["canonicalId"] = nil

--- a/sdk/nodejs/identity/groupAlias.ts
+++ b/sdk/nodejs/identity/groupAlias.ts
@@ -26,6 +26,7 @@ import * as utilities from "../utilities";
  * const groupAlias = new vault.identity.GroupAlias("group-alias", {
  *     canonicalId: group.id,
  *     mountAccessor: github.accessor,
+ *     name: "Github_Team_Slug",
  * });
  * ```
  *
@@ -94,6 +95,9 @@ export class GroupAlias extends pulumi.CustomResource {
             if (!args || args.mountAccessor === undefined) {
                 throw new Error("Missing required property 'mountAccessor'");
             }
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             inputs["canonicalId"] = args ? args.canonicalId : undefined;
             inputs["mountAccessor"] = args ? args.mountAccessor : undefined;
             inputs["name"] = args ? args.name : undefined;
@@ -142,5 +146,5 @@ export interface GroupAliasArgs {
     /**
      * Name of the group alias to create.
      */
-    readonly name?: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_vault/identity/group_alias.py
+++ b/sdk/python/pulumi_vault/identity/group_alias.py
@@ -59,6 +59,8 @@ class GroupAlias(pulumi.CustomResource):
             if mount_accessor is None:
                 raise TypeError("Missing required property 'mount_accessor'")
             __props__['mount_accessor'] = mount_accessor
+            if name is None:
+                raise TypeError("Missing required property 'name'")
             __props__['name'] = name
         super(GroupAlias, __self__).__init__(
             'vault:identity/groupAlias:GroupAlias',


### PR DESCRIPTION
Fixes: #11

There is an issue that without the groupAlias name being that of the Github Team Name, then the association didn't work as expected. This was what @nesl247 was pointing out in the attached issue