### PR TITLE
Change default max_lease_ttl_seconds to 1200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 _(none)_
+* Upgrade default value for `max_lease_ttl_seconds` to 1200
 
 ---
 

--- a/resources.go
+++ b/resources.go
@@ -168,7 +168,7 @@ func Provider() tfbridge.ProviderInfo {
 					EnvVars: []string{
 						"TERRAFORM_VAULT_MAX_TTL",
 					},
-					Value: 20,
+					Value: 1200,
 				},
 			},
 			"max_retries": {

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -37,7 +37,7 @@ namespace Pulumi.Vault
         /// <summary>
         /// Maximum TTL for secret leases requested by this provider
         /// </summary>
-        public static int? MaxLeaseTtlSeconds { get; set; } = __config.GetInt32("maxLeaseTtlSeconds") ?? Utilities.GetEnvInt32("TERRAFORM_VAULT_MAX_TTL") ?? 20;
+        public static int? MaxLeaseTtlSeconds { get; set; } = __config.GetInt32("maxLeaseTtlSeconds") ?? Utilities.GetEnvInt32("TERRAFORM_VAULT_MAX_TTL") ?? 1200;
 
         /// <summary>
         /// Maximum number of retries when a 5xx error code is encountered.

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -128,7 +128,7 @@ namespace Pulumi.Vault
             Address = Utilities.GetEnv("VAULT_ADDR");
             CaCertDir = Utilities.GetEnv("VAULT_CAPATH");
             CaCertFile = Utilities.GetEnv("VAULT_CACERT");
-            MaxLeaseTtlSeconds = Utilities.GetEnvInt32("TERRAFORM_VAULT_MAX_TTL") ?? 20;
+            MaxLeaseTtlSeconds = Utilities.GetEnvInt32("TERRAFORM_VAULT_MAX_TTL") ?? 1200;
             MaxRetries = Utilities.GetEnvInt32("VAULT_MAX_RETRIES") ?? 2;
             Namespace = Utilities.GetEnv("VAULT_NAMESPACE");
             SkipTlsVerify = Utilities.GetEnvBoolean("VAULT_SKIP_VERIFY");

--- a/sdk/go/vault/config/config.go
+++ b/sdk/go/vault/config/config.go
@@ -60,7 +60,7 @@ func GetMaxLeaseTtlSeconds(ctx *pulumi.Context) int {
 	if err == nil {
 		return v
 	}
-	if dv, ok := getEnvOrDefault(20, parseEnvInt, "TERRAFORM_VAULT_MAX_TTL").(int); ok {
+	if dv, ok := getEnvOrDefault(1200, parseEnvInt, "TERRAFORM_VAULT_MAX_TTL").(int); ok {
 		return dv
 	}
 	return v

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -29,7 +29,7 @@ export let clientAuths: { certFile: string, keyFile: string }[] | undefined = __
 /**
  * Maximum TTL for secret leases requested by this provider
  */
-export let maxLeaseTtlSeconds: number | undefined = __config.getObject<number>("maxLeaseTtlSeconds") || (utilities.getEnvNumber("TERRAFORM_VAULT_MAX_TTL") || 20);
+export let maxLeaseTtlSeconds: number | undefined = __config.getObject<number>("maxLeaseTtlSeconds") || (utilities.getEnvNumber("TERRAFORM_VAULT_MAX_TTL") || 1200);
 /**
  * Maximum number of retries when a 5xx error code is encountered.
  */

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -45,7 +45,7 @@ export class Provider extends pulumi.ProviderResource {
             inputs["caCertDir"] = (args ? args.caCertDir : undefined) || utilities.getEnv("VAULT_CAPATH");
             inputs["caCertFile"] = (args ? args.caCertFile : undefined) || utilities.getEnv("VAULT_CACERT");
             inputs["clientAuths"] = pulumi.output(args ? args.clientAuths : undefined).apply(JSON.stringify);
-            inputs["maxLeaseTtlSeconds"] = pulumi.output((args ? args.maxLeaseTtlSeconds : undefined) || (utilities.getEnvNumber("TERRAFORM_VAULT_MAX_TTL") || 20)).apply(JSON.stringify);
+            inputs["maxLeaseTtlSeconds"] = pulumi.output((args ? args.maxLeaseTtlSeconds : undefined) || (utilities.getEnvNumber("TERRAFORM_VAULT_MAX_TTL") || 1200)).apply(JSON.stringify);
             inputs["maxRetries"] = pulumi.output((args ? args.maxRetries : undefined) || (utilities.getEnvNumber("VAULT_MAX_RETRIES") || 2)).apply(JSON.stringify);
             inputs["namespace"] = (args ? args.namespace : undefined) || utilities.getEnv("VAULT_NAMESPACE");
             inputs["skipTlsVerify"] = pulumi.output((args ? args.skipTlsVerify : undefined) || utilities.getEnvBoolean("VAULT_SKIP_VERIFY")).apply(JSON.stringify);

--- a/sdk/python/pulumi_vault/config/vars.py
+++ b/sdk/python/pulumi_vault/config/vars.py
@@ -36,7 +36,7 @@ client_auths = __config__.get('clientAuths')
 Client authentication credentials.
 """
 
-max_lease_ttl_seconds = __config__.get('maxLeaseTtlSeconds') or (utilities.get_env_int('TERRAFORM_VAULT_MAX_TTL') or 20)
+max_lease_ttl_seconds = __config__.get('maxLeaseTtlSeconds') or (utilities.get_env_int('TERRAFORM_VAULT_MAX_TTL') or 1200)
 """
 Maximum TTL for secret leases requested by this provider
 """

--- a/sdk/python/pulumi_vault/provider.py
+++ b/sdk/python/pulumi_vault/provider.py
@@ -62,7 +62,7 @@ class Provider(pulumi.ProviderResource):
             __props__['ca_cert_file'] = ca_cert_file
             __props__['client_auths'] = pulumi.Output.from_input(client_auths).apply(json.dumps) if client_auths is not None else None
             if max_lease_ttl_seconds is None:
-                max_lease_ttl_seconds = (utilities.get_env_int('TERRAFORM_VAULT_MAX_TTL') or 20)
+                max_lease_ttl_seconds = (utilities.get_env_int('TERRAFORM_VAULT_MAX_TTL') or 1200)
             __props__['max_lease_ttl_seconds'] = pulumi.Output.from_input(max_lease_ttl_seconds).apply(json.dumps) if max_lease_ttl_seconds is not None else None
             if max_retries is None:
                 max_retries = (utilities.get_env_int('VAULT_MAX_RETRIES') or 2)


### PR DESCRIPTION
Fixes: #23

The default value that was added was 20 - this was supposed to be
minutes but is picked up as seconds. Therefore we can raise this
value to 1200 (60*20) to ensure the correct 20 minutes are accounted
for