### PR TITLE
Use initial AWS credentials when assuming second role

### DIFF
--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -27,24 +27,34 @@ fi
 # Tar up the plugin
 tar -czf ${PLUGIN_PACKAGE_PATH} -C ${WORK_PATH} .
 
+# Push the current AWS credentials, since we'll need them to assume a second role.
+export INITIAL_AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+export INITIAL_AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+
 # rel.pulumi.com is in our production account, so assume that role first
 CREDS_JSON=$(aws sts assume-role \
                  --role-arn "arn:aws:iam::058607598222:role/UploadPulumiReleases" \
                  --role-session-name "upload-plugin-pulumi-resource-vault" \
                  --external-id "upload-pulumi-release")
 
-# Use the credentials we just assumed
+# Use the credentials we just assumed.
 export AWS_ACCESS_KEY_ID=$(echo ${CREDS_JSON}     | jq ".Credentials.AccessKeyId" --raw-output)
 export AWS_SECRET_ACCESS_KEY=$(echo ${CREDS_JSON} | jq ".Credentials.SecretAccessKey" --raw-output)
 export AWS_SECURITY_TOKEN=$(echo ${CREDS_JSON}    | jq ".Credentials.SessionToken" --raw-output)
 
-echo "Uploading ${PLUGIN_PACKAGE_NAME}..."
+echo "Uploading ${PLUGIN_PACKAGE_NAME} to s3://rel.pulumi.com..."
 
 aws s3 cp --only-show-errors "${PLUGIN_PACKAGE_PATH}" "s3://rel.pulumi.com/releases/plugins/${PLUGIN_PACKAGE_NAME}"
 
 # Assume the role to publish plugins to s3://get.pulumi.com. We upload the plugins to two buckets while
 # we transition to only publishing/serving them from get.pulumi.com.
 echo "Uploading ${PLUGIN_PACKAGE_NAME} to s3://get.pulumi.com..."
+
+# Restore the initial AWS credentials we had, since the assumed role doesn't have the
+# ability to assume this other role to publish into a different bucket.
+export AWS_ACCESS_KEY_ID="${INITIAL_AWS_ACCESS_KEY_ID}"
+export AWS_SECRET_ACCESS_KEY="${INITIAL_AWS_SECRET_ACCESS_KEY}"
+unset AWS_SECURITY_TOKEN
 
 CREDS_JSON=$(aws sts assume-role \
                  --role-arn "arn:aws:iam::058607598222:role/PulumiUploadRelease" \

--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -52,9 +52,9 @@ echo "Uploading ${PLUGIN_PACKAGE_NAME} to s3://get.pulumi.com..."
 
 # Restore the initial AWS credentials we had, since the assumed role doesn't have the
 # ability to assume this other role to publish into a different bucket.
+unset {AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AWS_SECURITY_TOKEN}
 export AWS_ACCESS_KEY_ID="${INITIAL_AWS_ACCESS_KEY_ID}"
 export AWS_SECRET_ACCESS_KEY="${INITIAL_AWS_SECRET_ACCESS_KEY}"
-unset {AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AWS_SECURITY_TOKEN}
 
 CREDS_JSON=$(aws sts assume-role \
                  --role-arn "arn:aws:iam::058607598222:role/PulumiUploadRelease" \

--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -54,7 +54,7 @@ echo "Uploading ${PLUGIN_PACKAGE_NAME} to s3://get.pulumi.com..."
 # ability to assume this other role to publish into a different bucket.
 export AWS_ACCESS_KEY_ID="${INITIAL_AWS_ACCESS_KEY_ID}"
 export AWS_SECRET_ACCESS_KEY="${INITIAL_AWS_SECRET_ACCESS_KEY}"
-unset AWS_SECURITY_TOKEN
+unset {AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AWS_SECURITY_TOKEN}
 
 CREDS_JSON=$(aws sts assume-role \
                  --role-arn "arn:aws:iam::058607598222:role/PulumiUploadRelease" \


### PR DESCRIPTION
There was an error in #42 . We need to assume two different IAM Roles in order to publish to two different S3 buckets. However, we used the first assumed IAM Role when trying to assume the second Role, which reasonably fails.

```
An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts::058607598222:assumed-role/UploadPulumiReleases/upload-plugin-pulumi-resource-vault is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::058607598222:role/PulumiUploadRelease
```

Instead, we need to restore the initial AWS access key (i.e. for the IAM User we have hooked up to CI/CD) before trying to assume the second IAM Role.

There are other ways we could skin this cat, such as only having a single IAM Role that grants access to both buckets. But to keep the infrastructure side of things clearer while we migrate off of s3://rel.pulumi.com, I'd prefer to just do this extra work in the publish script.