### PR TITLE
Temporarily disable marking  `headers` provider arg as secret 

### DIFF
--- a/provider/cmd/pulumi-resource-vault/schema.json
+++ b/provider/cmd/pulumi-resource-vault/schema.json
@@ -147,8 +147,7 @@
                 "items": {
                     "$ref": "#/types/vault:config/headers:headers"
                 },
-                "description": "The headers to send with each Vault request.\n",
-                "secret": true
+                "description": "The headers to send with each Vault request.\n"
             },
             "maxLeaseTtlSeconds": {
                 "type": "integer",
@@ -6749,8 +6748,7 @@
                 "items": {
                     "$ref": "#/types/vault:index/ProviderHeader:ProviderHeader"
                 },
-                "description": "The headers to send with each Vault request.\n",
-                "secret": true
+                "description": "The headers to send with each Vault request.\n"
             },
             "maxLeaseTtlSeconds": {
                 "type": "integer",
@@ -6863,8 +6861,7 @@
                 "items": {
                     "$ref": "#/types/vault:index/ProviderHeader:ProviderHeader"
                 },
-                "description": "The headers to send with each Vault request.\n",
-                "secret": true
+                "description": "The headers to send with each Vault request.\n"
             },
             "maxLeaseTtlSeconds": {
                 "type": "integer",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -115,6 +115,9 @@ func Provider() tfbridge.ProviderInfo {
 	}
 	p := shimv2.NewProvider(generatedProvider.SchemaProvider())
 
+	// Temporarily override the secretness of `headers` field.
+	// https://github.com/pulumi/pulumi/issues/11278
+	overrideSecretFlagForHeaders := false
 	prov := tfbridge.ProviderInfo{
 		P:           p,
 		Name:        "vault",
@@ -147,6 +150,9 @@ func Provider() tfbridge.ProviderInfo {
 					},
 					Value: 2,
 				},
+			},
+			"headers": {
+				Secret: &overrideSecretFlagForHeaders,
 			},
 		},
 		PreConfigureCallback: preConfigureCallback,

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -199,11 +199,7 @@ namespace Pulumi.Vault
         public InputList<Inputs.ProviderHeaderArgs> Headers
         {
             get => _headers ?? (_headers = new InputList<Inputs.ProviderHeaderArgs>());
-            set
-            {
-                var emptySecret = Output.CreateSecret(ImmutableArray.Create<Inputs.ProviderHeaderArgs>());
-                _headers = Output.All(value, emptySecret).Apply(v => v[0]);
-            }
+            set => _headers = value;
         }
 
         /// <summary>

--- a/sdk/go/vault/provider.go
+++ b/sdk/go/vault/provider.go
@@ -58,9 +58,6 @@ func NewProvider(ctx *pulumi.Context,
 	if isZero(args.SkipTlsVerify) {
 		args.SkipTlsVerify = pulumi.BoolPtr(getEnvOrDefault(false, parseEnvBool, "VAULT_SKIP_VERIFY").(bool))
 	}
-	if args.Headers != nil {
-		args.Headers = pulumi.ToSecret(args.Headers).(ProviderHeaderArrayOutput)
-	}
 	var resource Provider
 	err := ctx.RegisterResource("pulumi:providers:vault", name, args, &resource, opts...)
 	if err != nil {

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -93,7 +93,7 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["caCertDir"] = args ? args.caCertDir : undefined;
             resourceInputs["caCertFile"] = args ? args.caCertFile : undefined;
             resourceInputs["clientAuth"] = pulumi.output(args ? args.clientAuth : undefined).apply(JSON.stringify);
-            resourceInputs["headers"] = pulumi.output(args?.headers ? pulumi.secret(args.headers) : undefined).apply(JSON.stringify);
+            resourceInputs["headers"] = pulumi.output(args ? args.headers : undefined).apply(JSON.stringify);
             resourceInputs["maxLeaseTtlSeconds"] = pulumi.output((args ? args.maxLeaseTtlSeconds : undefined) ?? (utilities.getEnvNumber("TERRAFORM_VAULT_MAX_TTL") || 1200)).apply(JSON.stringify);
             resourceInputs["maxRetries"] = pulumi.output((args ? args.maxRetries : undefined) ?? (utilities.getEnvNumber("VAULT_MAX_RETRIES") || 2)).apply(JSON.stringify);
             resourceInputs["maxRetriesCcc"] = pulumi.output(args ? args.maxRetriesCcc : undefined).apply(JSON.stringify);

--- a/sdk/python/pulumi_vault/provider.py
+++ b/sdk/python/pulumi_vault/provider.py
@@ -587,7 +587,7 @@ class Provider(pulumi.ProviderResource):
             __props__.__dict__["ca_cert_dir"] = ca_cert_dir
             __props__.__dict__["ca_cert_file"] = ca_cert_file
             __props__.__dict__["client_auth"] = pulumi.Output.from_input(client_auth).apply(pulumi.runtime.to_json) if client_auth is not None else None
-            __props__.__dict__["headers"] = None if pulumi.Output.from_input(headers).apply(pulumi.runtime.to_json) if headers is not None else None is None else pulumi.Output.secret(pulumi.Output.from_input(headers).apply(pulumi.runtime.to_json) if headers is not None else None)
+            __props__.__dict__["headers"] = pulumi.Output.from_input(headers).apply(pulumi.runtime.to_json) if headers is not None else None
             if max_lease_ttl_seconds is None:
                 max_lease_ttl_seconds = (_utilities.get_env_int('TERRAFORM_VAULT_MAX_TTL') or 1200)
             __props__.__dict__["max_lease_ttl_seconds"] = pulumi.Output.from_input(max_lease_ttl_seconds).apply(pulumi.runtime.to_json) if max_lease_ttl_seconds is not None else None


### PR DESCRIPTION
Core issue is tracked in https://github.com/pulumi/pulumi/issues/11278

Fixes #192 