### PR TITLE
Add alias for AuthBackendRoleSecretId -> AuthBackendRoleSecretID

### DIFF
--- a/provider/cmd/pulumi-resource-vault/schema.json
+++ b/provider/cmd/pulumi-resource-vault/schema.json
@@ -8416,7 +8416,12 @@
                     }
                 },
                 "type": "object"
-            }
+            },
+            "aliases": [
+                {
+                    "type": "vault:appRole/authBackendRoleSecretID:AuthBackendRoleSecretID"
+                }
+            ]
         },
         "vault:aws/authBackendCert:AuthBackendCert": {
             "description": "\n\n## Import\n\nAWS auth backend certificates can be imported using `auth/`, the `backend` path, `/config/certificate/`, and the `cert_name` e.g.\n\n```sh\n $ pulumi import vault:aws/authBackendCert:AuthBackendCert example auth/aws/config/certificate/my-cert\n```\n\n ",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -103,6 +103,10 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 	return nil
 }
 
+func stringRef(s string) *string {
+	return &s
+}
+
 // Provider returns additional overlaid schema and metadata associated with the provider.
 func Provider() tfbridge.ProviderInfo {
 	provider := vault.Provider()
@@ -201,9 +205,14 @@ func Provider() tfbridge.ProviderInfo {
 			},
 
 			// AppRole
-			"vault_approle_auth_backend_role":           {Tok: makeResource(appRoleMod, "AuthBackendRole")},
-			"vault_approle_auth_backend_login":          {Tok: makeResource(appRoleMod, "AuthBackendLogin")},
-			"vault_approle_auth_backend_role_secret_id": {Tok: makeResource(appRoleMod, "AuthBackendRoleSecretId")},
+			"vault_approle_auth_backend_role":  {Tok: makeResource(appRoleMod, "AuthBackendRole")},
+			"vault_approle_auth_backend_login": {Tok: makeResource(appRoleMod, "AuthBackendLogin")},
+			"vault_approle_auth_backend_role_secret_id": {
+				Tok: makeResource(appRoleMod, "AuthBackendRoleSecretId"),
+				Aliases: []tfbridge.AliasInfo{
+					{Type: stringRef(makeResource(appRoleMod, "AuthBackendRoleSecretID").String())},
+				},
+			},
 
 			// AliCloud
 			"vault_alicloud_auth_backend_role": {Tok: makeResource(aliCloudMod, "AuthBackendRole")},

--- a/sdk/dotnet/AppRole/AuthBackendRoleSecretId.cs
+++ b/sdk/dotnet/AppRole/AuthBackendRoleSecretId.cs
@@ -158,6 +158,10 @@ namespace Pulumi.Vault.AppRole
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                Aliases =
+                {
+                    new global::Pulumi.Alias { Type = "vault:appRole/authBackendRoleSecretID:AuthBackendRoleSecretID"},
+                },
                 AdditionalSecretOutputs =
                 {
                     "secretId",

--- a/sdk/go/vault/approle/authBackendRoleSecretId.go
+++ b/sdk/go/vault/approle/authBackendRoleSecretId.go
@@ -119,6 +119,12 @@ func NewAuthBackendRoleSecretId(ctx *pulumi.Context,
 	if args.RoleName == nil {
 		return nil, errors.New("invalid value for required argument 'RoleName'")
 	}
+	aliases := pulumi.Aliases([]pulumi.Alias{
+		{
+			Type: pulumi.String("vault:appRole/authBackendRoleSecretID:AuthBackendRoleSecretID"),
+		},
+	})
+	opts = append(opts, aliases)
 	if args.SecretId != nil {
 		args.SecretId = pulumi.ToSecret(args.SecretId).(pulumi.StringPtrOutput)
 	}

--- a/sdk/java/src/main/java/com/pulumi/vault/appRole/AuthBackendRoleSecretId.java
+++ b/sdk/java/src/main/java/com/pulumi/vault/appRole/AuthBackendRoleSecretId.java
@@ -3,6 +3,7 @@
 
 package com.pulumi.vault.appRole;
 
+import com.pulumi.core.Alias;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Export;
 import com.pulumi.core.annotations.ResourceType;
@@ -288,6 +289,9 @@ public class AuthBackendRoleSecretId extends com.pulumi.resources.CustomResource
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .aliases(List.of(
+                Output.of(Alias.builder().type("vault:appRole/authBackendRoleSecretID:AuthBackendRoleSecretID").build())
+            ))
             .additionalSecretOutputs(List.of(
                 "secretId",
                 "wrappingToken"

--- a/sdk/nodejs/approle/authBackendRoleSecretId.ts
+++ b/sdk/nodejs/approle/authBackendRoleSecretId.ts
@@ -161,6 +161,8 @@ export class AuthBackendRoleSecretId extends pulumi.CustomResource {
             resourceInputs["wrappingToken"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const aliasOpts = { aliases: [{ type: "vault:appRole/authBackendRoleSecretID:AuthBackendRoleSecretID" }] };
+        opts = pulumi.mergeOptions(opts, aliasOpts);
         const secretOpts = { additionalSecretOutputs: ["secretId", "wrappingToken"] };
         opts = pulumi.mergeOptions(opts, secretOpts);
         super(AuthBackendRoleSecretId.__pulumiType, name, resourceInputs, opts);

--- a/sdk/python/pulumi_vault/approle/auth_backend_role_secret_id.py
+++ b/sdk/python/pulumi_vault/approle/auth_backend_role_secret_id.py
@@ -521,6 +521,8 @@ class AuthBackendRoleSecretId(pulumi.CustomResource):
             __props__.__dict__["accessor"] = None
             __props__.__dict__["wrapping_accessor"] = None
             __props__.__dict__["wrapping_token"] = None
+        alias_opts = pulumi.ResourceOptions(aliases=[pulumi.Alias(type_="vault:appRole/authBackendRoleSecretID:AuthBackendRoleSecretID")])
+        opts = pulumi.ResourceOptions.merge(opts, alias_opts)
         secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["secretId", "wrappingToken"])
         opts = pulumi.ResourceOptions.merge(opts, secret_opts)
         super(AuthBackendRoleSecretId, __self__).__init__(


### PR DESCRIPTION
Fixes #201.

In https://github.com/pulumi/pulumi-vault/pull/190 a case change for the existing type token leaked through. This change adds an alias to ensure existing resources with the old type token can be deduped. Note that a code change might still be required but that is in essence not seen as a breaking change (an errant update due to a missing alias is breaking however, which this fixes). FWIW this provider mixes conventions for type tokens. We have resorted to using the current convention for new type tokens. We don't intend to update tokens for existing resources however.