### PR TITLE
Test pulumi-vault

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -27,6 +27,7 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   TRAVIS_OS_NAME: linux
+  VAULT_DEV_ROOT_TOKEN_ID: "root"
 jobs:
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -14,7 +14,10 @@ import (
 // If the test is running in CI, a missing token will fail the test. Otherwise a missing
 // token will skip the test.
 func getToken(t *testing.T) string {
-	env := "VAULT_DEV_ROOT_TOKEN_ID"
+	return getEnv(t, "VAULT_DEV_ROOT_TOKEN_ID")
+}
+
+func getEnv(t *testing.T, env string) string {
 	token := os.Getenv(env)
 	if token != "" {
 		return token

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -9,12 +9,20 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
 
+// Retrieve the token.
+//
+// If the test is running in CI, a missing token will fail the test. Otherwise a missing
+// token will skip the test.
 func getToken(t *testing.T) string {
-	token := os.Getenv("VAULT_DEV_ROOT_TOKEN_ID")
-	if token == "" {
-		t.Skipf("Skipping test due to missing VAULT_DEV_ROOT_TOKEN_ID environment variable")
+	env := "VAULT_DEV_ROOT_TOKEN_ID"
+	token := os.Getenv(env)
+	if token != "" {
+		return token
 	}
-
+	if os.Getenv("CI") != "" {
+		t.Fatalf("%q is expected but not defined", env)
+	}
+	t.Skipf("Skipping test due to missing %q environment variable", env)
 	return token
 }
 

--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -1,11 +1,8 @@
 version: "3"
 services:
   vault:
-    image: hashicorp/vault:latest
-    cap_add:
-      - IPC_LOCK
+    image: hashicorp/vault:1.14.2
     environment:
       - VAULT_DEV_ROOT_TOKEN_ID=root
     ports:
-      - 8200:8200
-    command: vault server -dev
+      - "8200:8200"


### PR DESCRIPTION
This PR does two things:
1. Ensures that our tests run, by failing the test when we do not have the env vars necessary to continue.
2. Install a pre-BSL version of vault, configure it, and test against it.