### PR TITLE
Use version 0.0.9 of pulumi-package-publisher

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -307,7 +307,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.12
+      uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.12
+      uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,7 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.12
+      uses: pulumi/pulumi-package-publisher@v0.0.9
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"


### PR DESCRIPTION
The version of pulumi-package-publisher used in the latest release does not account for the old nodejs install scripts, that the version of the bridge we are using still generates. Version 0.0.9 has a hotfix meant to address an npm install failure that expects these scripts.

We can verify this works after merge to default branch, and then installing `latest`. Then we can push a patch.

Read context here: https://github.com/pulumi/pulumi-github/pull/377

Fixes #321.
