### PR TITLE
Fix "docker-compose" -> "docker compose"

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -495,8 +495,8 @@ jobs:
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
-    - name: Run docker-compose
-      run: docker-compose -f testing/docker-compose.yml up --build -d
+    - name: Run docker compose
+      run: docker compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
     - name: Install gotestfmt

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -416,8 +416,8 @@ jobs:
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
-    - name: Run docker-compose
-      run: docker-compose -f testing/docker-compose.yml up --build -d
+    - name: Run docker compose
+      run: docker compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
     - name: Install gotestfmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -464,8 +464,8 @@ jobs:
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
-    - name: Run docker-compose
-      run: docker-compose -f testing/docker-compose.yml up --build -d
+    - name: Run docker compose
+      run: docker compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
     - name: Install gotestfmt

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -412,8 +412,8 @@ jobs:
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
-    - name: Run docker-compose
-      run: docker-compose -f testing/docker-compose.yml up --build -d
+    - name: Run docker compose
+      run: docker compose -f testing/docker-compose.yml up --build -d
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
     - name: Install gotestfmt


### PR DESCRIPTION
This was accomplished by running `make ci-mgmt` then removing the problematic caching component.

Because this mirrored an automatic process, I'm going to merge without a PR review.