### PR TITLE
docs: fix jwt & kubernetes go examples

### DIFF
--- a/sdk/go/vault/jwt/authBackendRole.go
+++ b/sdk/go/vault/jwt/authBackendRole.go
@@ -33,14 +33,14 @@ import (
 //
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
-//			jwt, err := jwt.NewAuthBackend(ctx, "jwt", &jwt.AuthBackendArgs{
+//			jwtRes, err := jwt.NewAuthBackend(ctx, "jwt", &jwt.AuthBackendArgs{
 //				Path: pulumi.String("jwt"),
 //			})
 //			if err != nil {
 //				return err
 //			}
 //			_, err = jwt.NewAuthBackendRole(ctx, "example", &jwt.AuthBackendRoleArgs{
-//				Backend:  jwt.Path,
+//				Backend:  jwtRes.Path,
 //				RoleName: pulumi.String("test-role"),
 //				TokenPolicies: pulumi.StringArray{
 //					pulumi.String("default"),

--- a/sdk/go/vault/kubernetes/authBackendConfig.go
+++ b/sdk/go/vault/kubernetes/authBackendConfig.go
@@ -32,14 +32,14 @@ import (
 //
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
-//			kubernetes, err := vault.NewAuthBackend(ctx, "kubernetes", &vault.AuthBackendArgs{
+//			kubernetesRes, err := vault.NewAuthBackend(ctx, "kubernetes", &vault.AuthBackendArgs{
 //				Type: pulumi.String("kubernetes"),
 //			})
 //			if err != nil {
 //				return err
 //			}
 //			_, err = kubernetes.NewAuthBackendConfig(ctx, "example", &kubernetes.AuthBackendConfigArgs{
-//				Backend:              kubernetes.Path,
+//				Backend:              kubernetesRes.Path,
 //				KubernetesHost:       pulumi.String("http://example.com:443"),
 //				KubernetesCaCert:     pulumi.String("-----BEGIN CERTIFICATE-----\nexample\n-----END CERTIFICATE-----"),
 //				TokenReviewerJwt:     pulumi.String("ZXhhbXBsZQo="),

--- a/sdk/go/vault/kubernetes/authBackendRole.go
+++ b/sdk/go/vault/kubernetes/authBackendRole.go
@@ -32,14 +32,14 @@ import (
 //
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
-//			kubernetes, err := vault.NewAuthBackend(ctx, "kubernetes", &vault.AuthBackendArgs{
+//			kubernetesRes, err := vault.NewAuthBackend(ctx, "kubernetes", &vault.AuthBackendArgs{
 //				Type: pulumi.String("kubernetes"),
 //			})
 //			if err != nil {
 //				return err
 //			}
 //			_, err = kubernetes.NewAuthBackendRole(ctx, "example", &kubernetes.AuthBackendRoleArgs{
-//				Backend:  kubernetes.Path,
+//				Backend:  kubernetesRes.Path,
 //				RoleName: pulumi.String("example-role"),
 //				BoundServiceAccountNames: pulumi.StringArray{
 //					pulumi.String("example"),


### PR DESCRIPTION
go examples on [jwt/authbackendrole](https://www.pulumi.com/registry/packages/vault/api-docs/jwt/authbackendrole/) and [kubernetes/authbackendconfig](https://www.pulumi.com/registry/packages/vault/api-docs/kubernetes/authbackendconfig/) not working, this is the fix~