### PR TITLE
Fix auth login provider configuration encoding

### DIFF
--- a/patches/0002-Align-Plugin-Framework-auth-login-block-cardinality.patch
+++ b/patches/0002-Align-Plugin-Framework-auth-login-block-cardinality.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: corymhall <43035978+corymhall@users.noreply.github.com>
+Date: Mon, 10 Aug 2026 14:47:25 -0400
+Subject: [PATCH] Align Plugin Framework auth login block cardinality
+
+The SDKv2 provider limits every auth_login block to one item. Apply the
+same constraint to the duplicated Plugin Framework schema so consumers
+do not derive incompatible provider configuration shapes.
+
+diff --git a/internal/provider/fwprovider/auth.go b/internal/provider/fwprovider/auth.go
+index ecbf16f1..a868463f 100644
+--- a/internal/provider/fwprovider/auth.go
++++ b/internal/provider/fwprovider/auth.go
+@@ -7,6 +7,7 @@ import (
+ 	"fmt"
+ 
+ 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
++	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+ 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+ 	"github.com/hashicorp/terraform-plugin-framework/path"
+ 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+@@ -16,6 +17,8 @@ import (
+ )
+ 
+ func mustAddLoginSchema(s *schema.ListNestedBlock, defaultMount string) schema.Block {
++	s.Validators = append(s.Validators, listvalidator.SizeAtMost(1))
++
+ 	m := map[string]schema.Attribute{
+ 		consts.FieldNamespace: schema.StringAttribute{
+ 			Optional: true,

--- a/provider/provider_config_test.go
+++ b/provider/provider_config_test.go
@@ -1,0 +1,72 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	_ "embed"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	pfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"github.com/pulumi/pulumi-vault/provider/v7/pkg/version"
+)
+
+//go:embed cmd/pulumi-resource-vault/schema.json
+var testPulumiSchema []byte
+
+func TestProviderConfigAuthLoginAwsObject(t *testing.T) {
+	previousVersion := version.Version
+	version.Version = "7.11.0"
+	t.Cleanup(func() {
+		version.Version = previousVersion
+	})
+
+	info := Provider()
+
+	server, err := pfbridge.MakeMuxedServer(
+		context.Background(), "vault", info, testPulumiSchema,
+	)(nil)
+	require.NoError(t, err)
+
+	news, err := structpb.NewStruct(map[string]any{
+		"address": "https://vault.example.internal",
+		"authLoginAws": map[string]any{
+			"awsRegion": "us-east-1",
+			"role":      "my-role",
+		},
+		"skipChildToken": true,
+		"version":        "7.11.0",
+	})
+	require.NoError(t, err)
+
+	response, err := server.CheckConfig(context.Background(), &pulumirpc.CheckRequest{
+		Urn:  "urn:pulumi:dev::test::pulumi:providers:vault::vault-provider",
+		News: news,
+	})
+	require.NoError(t, err)
+	require.Empty(t, response.Failures)
+	require.NotNil(t, response.Inputs)
+	authLoginAws, ok := response.Inputs.Fields["authLoginAws"]
+	require.True(t, ok)
+	require.JSONEq(t,
+		`{"awsRegion":"us-east-1","role":"my-role"}`,
+		authLoginAws.GetStringValue())
+}


### PR DESCRIPTION
Vault's SDKv2 provider schema limits each `auth_login_*` configuration block to one item, so the Pulumi schema exposes these settings as objects. The duplicated Plugin Framework schema did not include the same limit. After the v7.11.0 mux change, an object-shaped `authLoginAws` configuration therefore failed before provider validation:

```text
cannot encode provider configuration to call ValidateProviderConfig: objectEncoder failed on property "auth_login_aws": Expected an Array PropertyValue
```

This applies the focused upstream schema fix from https://github.com/hashicorp/terraform-provider-vault/pull/2991 as a temporary patch. The patch adds the missing single-item validator through Vault's shared auth login schema helper, so it covers all `auth_login_*` configurations. It can be removed after a Vault release contains the upstream fix.

The regression test sends an object-shaped `authLoginAws` value through the real mux server's `CheckConfig` RPC. The test reproduces the encoder error without the patch and passes with the patch.

The bridge-level handling of SDKv2 and Plugin Framework schema differences remains tracked by https://github.com/pulumi/pulumi-terraform-bridge/issues/3566.

Fixes #1087

Validation:

```console
$ cd provider && go test . -run TestProviderConfigAuthLoginAwsObject -count=1
$ make test_provider
$ make lint
```
